### PR TITLE
Add internet speed display

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -28,6 +28,14 @@
   color: #61dafb;
 }
 
+.good-speed {
+  color: green;
+}
+
+.bad-speed {
+  color: red;
+}
+
 @keyframes App-logo-spin {
   from {
     transform: rotate(0deg);

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,41 @@
 import logo from './logo.svg';
 import './App.css';
+import { useEffect, useState } from 'react';
 
 function App() {
+  const [speed, setSpeed] = useState(null);
+
+  useEffect(() => {
+    const measureSpeed = async () => {
+      if (navigator.connection && navigator.connection.downlink) {
+        setSpeed(navigator.connection.downlink);
+        return;
+      }
+      try {
+        const image =
+          "https://upload.wikimedia.org/wikipedia/commons/3/3f/Fronalpstock_big.jpg";
+        const startTime = performance.now();
+        const response = await fetch(image + "?cache=" + startTime, {
+          cache: "no-cache",
+        });
+        const blob = await response.blob();
+        const endTime = performance.now();
+        const duration = (endTime - startTime) / 1000;
+        const bitsLoaded = blob.size * 8;
+        const mbps = bitsLoaded / duration / (1024 * 1024);
+        setSpeed(mbps);
+      } catch (e) {
+        setSpeed(null);
+      }
+    };
+
+    measureSpeed();
+  }, []);
+
+  const speedClass = speed !== null && speed >= 5 ? "good-speed" : "bad-speed";
+  const speedText =
+    speed !== null ? `${speed.toFixed(2)} Mbps` : "Unable to determine speed";
+
   return (
     <div className="App">
       <header className="App-header">
@@ -17,6 +51,7 @@ function App() {
         >
           Learn React
         </a>
+        <p className={speedClass}>Internet speed: {speedText}</p>
       </header>
     </div>
   );


### PR DESCRIPTION
## Summary
- measure user network speed on load
- color code the speed display in green or red

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68542ac42068832d9f357bb864f605a8