### PR TITLE
Fix Add Lead button to create lead

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,87 +1,13 @@
 import './App.css';
-import { Form, Input, Button, Select, message } from 'antd';
-import { useCreateLead } from './_actions/leads';
-
-const { TextArea } = Input;
+import AddLeadForm from './leads/AddLeadForm';
 
 function App() {
-    const [form] = Form.useForm();
-    const createLead = useCreateLead();
-
-    const onFinish = (values) => {
-        createLead.mutate(values, {
-            onSuccess: () => {
-                message.success('Lead added successfully');
-                form.resetFields();
-            },
-            onError: () => message.error('Failed to add lead'),
-        });
-    };
-
-    return (
-        <div className="App">
-            <h3>Add New Lead</h3>
-            <Form
-                form={form}
-                layout="vertical"
-                onFinish={onFinish}
-                style={{ maxWidth: 600, margin: '0 auto' }}
-            >
-                <Form.Item
-                    label="Full Name"
-                    name="full_name"
-                    rules={[{ required: true, message: 'Please enter full name' }]}
-                >
-                    <Input />
-                </Form.Item>
-                <Form.Item
-                    label="Email"
-                    name="email"
-                    rules={[{ required: true, type: 'email' }]}
-                >
-                    <Input />
-                </Form.Item>
-                <Form.Item
-                    label="Contact Number"
-                    name="contact_no"
-                    rules={[{ required: true }]}
-                >
-                    <Input />
-                </Form.Item>
-                <Form.Item label="Company Name" name="company_name">
-                    <Input />
-                </Form.Item>
-                <Form.Item label="Requirement" name="requirement">
-                    <TextArea rows={4} />
-                </Form.Item>
-                <Form.Item
-                    label="Email To"
-                    name="email_to"
-                    rules={[{ type: 'email', required: true }]}
-                >
-                    <Input />
-                </Form.Item>
-                <Form.Item
-                    label="Status"
-                    name="status"
-                    rules={[{ required: true }]}
-                >
-                    <Select
-                        options={[
-                            { value: 'active', label: 'Active' },
-                            { value: 'closed', label: 'Closed' },
-                            { value: 'on_hold', label: 'On Hold' },
-                        ]}
-                    />
-                </Form.Item>
-                <Form.Item>
-                    <Button type="primary" htmlType="submit" loading={createLead.isPending}>
-                        Add Lead
-                    </Button>
-                </Form.Item>
-            </Form>
-        </div>
-    );
+  return (
+    <div className="App">
+      <h3>Add New Lead</h3>
+      <AddLeadForm />
+    </div>
+  );
 }
 
 export default App;

--- a/src/leads/AddLeadForm.js
+++ b/src/leads/AddLeadForm.js
@@ -1,0 +1,83 @@
+import { Form, Input, Button, Select, message } from 'antd';
+import { useCreateLead } from '../_actions/leads';
+
+const { TextArea } = Input;
+
+const AddLeadForm = () => {
+  const [form] = Form.useForm();
+  const createLead = useCreateLead();
+
+  const onFinish = (values) => {
+    createLead.mutate(values, {
+      onSuccess: () => {
+        message.success('Lead added successfully');
+        form.resetFields();
+      },
+      onError: () => message.error('Failed to add lead'),
+    });
+  };
+
+  return (
+    <Form
+      form={form}
+      layout="vertical"
+      onFinish={onFinish}
+      style={{ maxWidth: 600, margin: '0 auto' }}
+    >
+      <Form.Item
+        label="Full Name"
+        name="full_name"
+        rules={[{ required: true, message: 'Please enter full name' }]}
+      >
+        <Input />
+      </Form.Item>
+      <Form.Item
+        label="Email"
+        name="email"
+        rules={[{ required: true, type: 'email' }]}
+      >
+        <Input />
+      </Form.Item>
+      <Form.Item
+        label="Contact Number"
+        name="contact_no"
+        rules={[{ required: true }]}
+      >
+        <Input />
+      </Form.Item>
+      <Form.Item label="Company Name" name="company_name">
+        <Input />
+      </Form.Item>
+      <Form.Item label="Requirement" name="requirement">
+        <TextArea rows={4} />
+      </Form.Item>
+      <Form.Item
+        label="Email To"
+        name="email_to"
+        rules={[{ type: 'email', required: true }]}
+      >
+        <Input />
+      </Form.Item>
+      <Form.Item
+        label="Status"
+        name="status"
+        rules={[{ required: true }]}
+      >
+        <Select
+          options={[
+            { value: 'active', label: 'Active' },
+            { value: 'closed', label: 'Closed' },
+            { value: 'on_hold', label: 'On Hold' },
+          ]}
+        />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit" loading={createLead.isPending}>
+          Add Lead
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+};
+
+export default AddLeadForm;


### PR DESCRIPTION
## Summary
- extract a dedicated AddLeadForm component under `src/leads/`
- show the new form on the homepage

## Testing
- `npm test --silent --maxWorkers=2` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68553e9265a8832da74104067dc82b1c