### PR TITLE
Add leads table below form

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,13 @@
 import './App.css';
 import AddLeadForm from './leads/AddLeadForm';
+import LeadsTable from './leads/LeadsTable';
 
 function App() {
   return (
     <div className="App">
       <h3>Add New Lead</h3>
       <AddLeadForm />
+      <LeadsTable />
     </div>
   );
 }

--- a/src/_actions/leads.js
+++ b/src/_actions/leads.js
@@ -1,10 +1,17 @@
-import { useMutation } from '@tanstack/react-query';
-import { createItem } from './api';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { createItem, getItems } from './api';
 
 const COLLECTION = 'qcrm_leads';
 
 export const useCreateLead = () => {
   return useMutation({
     mutationFn: (data) => createItem(COLLECTION, data),
+  });
+};
+
+export const useGetLeads = () => {
+  return useQuery({
+    queryKey: [COLLECTION],
+    queryFn: () => getItems(COLLECTION),
   });
 };

--- a/src/leads/LeadsTable.js
+++ b/src/leads/LeadsTable.js
@@ -1,0 +1,66 @@
+import { Table, Tag } from 'antd';
+import { useGetLeads } from '../_actions/leads';
+
+const statusColors = {
+  active: 'green',
+  on_hold: 'gray',
+  closed: 'red',
+};
+
+const LeadsTable = () => {
+  const { data = [], isLoading } = useGetLeads();
+
+  const columns = [
+    {
+      title: 'Full Name',
+      dataIndex: 'full_name',
+      key: 'full_name',
+    },
+    {
+      title: 'Email',
+      dataIndex: 'email',
+      key: 'email',
+    },
+    {
+      title: 'Contact No',
+      dataIndex: 'contact_no',
+      key: 'contact_no',
+    },
+    {
+      title: 'Company',
+      dataIndex: 'company_name',
+      key: 'company_name',
+    },
+    {
+      title: 'Requirement',
+      dataIndex: 'requirement',
+      key: 'requirement',
+    },
+    {
+      title: 'Email To',
+      dataIndex: 'email_to',
+      key: 'email_to',
+    },
+    {
+      title: 'Status',
+      dataIndex: 'status',
+      key: 'status',
+      render: (status) => (
+        <Tag color={statusColors[status] || 'default'}>{status}</Tag>
+      ),
+    },
+  ];
+
+  return (
+    <Table
+      rowKey="id"
+      loading={isLoading}
+      columns={columns}
+      dataSource={data}
+      pagination={false}
+      style={{ marginTop: 20 }}
+    />
+  );
+};
+
+export default LeadsTable;


### PR DESCRIPTION
## Summary
- fetch CRM leads via `useGetLeads`
- display all leads in new `LeadsTable` component
- show status tags in color
- include leads table on homepage

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855420166b4832d95dbba41d58eb6c7