### PR TITLE
Improve Add Lead form UI

### DIFF
--- a/src/leads/AddLeadForm.js
+++ b/src/leads/AddLeadForm.js
@@ -1,4 +1,4 @@
-import { Form, Input, Button, Select, message } from 'antd';
+import { Form, Input, Button, Select, message, Row, Col } from 'antd';
 import { useCreateLead } from '../_actions/leads';
 
 const { TextArea } = Input;
@@ -22,56 +22,74 @@ const AddLeadForm = () => {
       form={form}
       layout="vertical"
       onFinish={onFinish}
-      style={{ maxWidth: 600, margin: '0 auto' }}
+      style={{ maxWidth: 800, margin: '0 auto' }}
     >
-      <Form.Item
-        label="Full Name"
-        name="full_name"
-        rules={[{ required: true, message: 'Please enter full name' }]}
-      >
-        <Input />
-      </Form.Item>
-      <Form.Item
-        label="Email"
-        name="email"
-        rules={[{ required: true, type: 'email' }]}
-      >
-        <Input />
-      </Form.Item>
-      <Form.Item
-        label="Contact Number"
-        name="contact_no"
-        rules={[{ required: true }]}
-      >
-        <Input />
-      </Form.Item>
-      <Form.Item label="Company Name" name="company_name">
-        <Input />
-      </Form.Item>
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item
+            label="Full Name"
+            name="full_name"
+            rules={[{ required: true, message: 'Please enter full name' }]}
+          >
+            <Input />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            label="Email"
+            name="email"
+            rules={[{ required: true, type: 'email' }]}
+          >
+            <Input />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item
+            label="Contact Number"
+            name="contact_no"
+            rules={[{ required: true }]}
+          >
+            <Input />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item label="Company Name" name="company_name">
+            <Input />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item
+            label="Email To"
+            name="email_to"
+            rules={[{ type: 'email', required: true }]}
+          >
+            <Input />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            label="Status"
+            name="status"
+            rules={[{ required: true }]}
+          >
+            <Select
+              options={[
+                { value: 'active', label: 'Active' },
+                { value: 'closed', label: 'Closed' },
+                { value: 'on_hold', label: 'On Hold' },
+              ]}
+            />
+          </Form.Item>
+        </Col>
+      </Row>
       <Form.Item label="Requirement" name="requirement">
         <TextArea rows={4} />
       </Form.Item>
-      <Form.Item
-        label="Email To"
-        name="email_to"
-        rules={[{ type: 'email', required: true }]}
-      >
-        <Input />
-      </Form.Item>
-      <Form.Item
-        label="Status"
-        name="status"
-        rules={[{ required: true }]}
-      >
-        <Select
-          options={[
-            { value: 'active', label: 'Active' },
-            { value: 'closed', label: 'Closed' },
-            { value: 'on_hold', label: 'On Hold' },
-          ]}
-        />
-      </Form.Item>
-      <Form.Item>
+      <Form.Item style={{ textAlign: 'right' }}>
         <Button type="primary" htmlType="submit" loading={createLead.isPending}>
           Add Lead
         </Button>


### PR DESCRIPTION
## Summary
- update `AddLeadForm` with two column layout and new styling

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685542bd3b80832d87cdc100fc701b45