### PR TITLE
Add status actions for leads

### DIFF
--- a/src/_actions/leads.js
+++ b/src/_actions/leads.js
@@ -1,5 +1,5 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { createItem, getItems } from './api';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { createItem, getItems, updateItem } from './api';
 
 const COLLECTION = 'qcrm_leads';
 
@@ -13,5 +13,13 @@ export const useGetLeads = () => {
   return useQuery({
     queryKey: [COLLECTION],
     queryFn: () => getItems(COLLECTION),
+  });
+};
+
+export const useUpdateLead = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, ...data }) => updateItem(COLLECTION, id, data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: [COLLECTION] }),
   });
 };

--- a/src/leads/LeadsTable.js
+++ b/src/leads/LeadsTable.js
@@ -1,5 +1,5 @@
-import { Table, Tag } from 'antd';
-import { useGetLeads } from '../_actions/leads';
+import { Table, Tag, Button, message } from 'antd';
+import { useGetLeads, useUpdateLead } from '../_actions/leads';
 
 const statusColors = {
   active: 'green',
@@ -9,6 +9,17 @@ const statusColors = {
 
 const LeadsTable = () => {
   const { data = [], isLoading } = useGetLeads();
+  const updateLead = useUpdateLead();
+
+  const handleStatusChange = (id, status) => {
+    updateLead.mutate(
+      { id, status },
+      {
+        onSuccess: () => message.success('Status updated'),
+        onError: () => message.error('Failed to update status'),
+      }
+    );
+  };
 
   const columns = [
     {
@@ -48,6 +59,43 @@ const LeadsTable = () => {
       render: (status) => (
         <Tag color={statusColors[status] || 'default'}>{status}</Tag>
       ),
+    },
+    {
+      title: 'Actions',
+      key: 'actions',
+      render: (_, record) => {
+        if (record.status === 'active') {
+          return (
+            <>
+              <Button
+                size="small"
+                onClick={() => handleStatusChange(record.id, 'on_hold')}
+                style={{ marginRight: 8 }}
+              >
+                Hold
+              </Button>
+              <Button
+                size="small"
+                danger
+                onClick={() => handleStatusChange(record.id, 'closed')}
+              >
+                Close
+              </Button>
+            </>
+          );
+        }
+        if (record.status === 'closed' || record.status === 'on_hold') {
+          return (
+            <Button
+              size="small"
+              onClick={() => handleStatusChange(record.id, 'active')}
+            >
+              Open
+            </Button>
+          );
+        }
+        return null;
+      },
     },
   ];
 


### PR DESCRIPTION
## Summary
- enable updating lead status via API
- show action buttons in leads table to update status

## Testing
- `npm test -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855436aaee8832dbf479eeee0ce8952