### PR TITLE
Fix leads table refresh after adding

### DIFF
--- a/src/_actions/leads.js
+++ b/src/_actions/leads.js
@@ -4,8 +4,11 @@ import { createItem, getItems, updateItem } from './api';
 const COLLECTION = 'qcrm_leads';
 
 export const useCreateLead = () => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (data) => createItem(COLLECTION, data),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: [COLLECTION] }),
   });
 };
 


### PR DESCRIPTION
## Summary
- refresh lead list from API once a new lead is created

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685543f97ce4832da80b0477b5d126f3