### PR TITLE
Add dashboard and sidebar navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "web-vitals": "^2.1.4",
     "three": "^0.155.0",
     "antd": "^5.13.6",
-    "@tanstack/react-query": "^5.24.3"
+    "@tanstack/react-query": "^5.24.3",
+    "@ant-design/plots": "^1.5.17"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,56 @@
 import './App.css';
+import { Layout, Menu } from 'antd';
+import {
+  DashboardOutlined,
+  TableOutlined,
+  PlusOutlined,
+  InfoCircleOutlined,
+} from '@ant-design/icons';
+import { useState } from 'react';
 import AddLeadForm from './leads/AddLeadForm';
 import LeadsTable from './leads/LeadsTable';
+import Dashboard from './dashboard/Dashboard';
+import About from './about/About';
+
+const { Sider, Content } = Layout;
 
 function App() {
+  const [current, setCurrent] = useState('dashboard');
+
+  const renderContent = () => {
+    switch (current) {
+      case 'dashboard':
+        return <Dashboard />;
+      case 'add':
+        return <AddLeadForm />;
+      case 'leads':
+        return <LeadsTable />;
+      case 'about':
+        return <About />;
+      default:
+        return null;
+    }
+  };
+
   return (
-    <div className="App">
-      <h3>Add New Lead</h3>
-      <AddLeadForm />
-      <LeadsTable />
-    </div>
+    <Layout style={{ minHeight: '100vh' }}>
+      <Sider collapsible>
+        <Menu
+          theme="dark"
+          mode="inline"
+          selectedKeys={[current]}
+          onClick={({ key }) => setCurrent(key)}
+        >
+          <Menu.Item key="dashboard" icon={<DashboardOutlined />}>Dashboard</Menu.Item>
+          <Menu.Item key="leads" icon={<TableOutlined />}>All Leads</Menu.Item>
+          <Menu.Item key="add" icon={<PlusOutlined />}>Add New Lead</Menu.Item>
+          <Menu.Item key="about" icon={<InfoCircleOutlined />}>About</Menu.Item>
+        </Menu>
+      </Sider>
+      <Layout>
+        <Content style={{ margin: '16px' }}>{renderContent()}</Content>
+      </Layout>
+    </Layout>
   );
 }
 

--- a/src/about/About.js
+++ b/src/about/About.js
@@ -1,0 +1,24 @@
+import { Typography } from 'antd';
+
+const { Title, Paragraph } = Typography;
+
+const About = () => (
+  <Typography>
+    <Title level={2}>CRM Tutorial</Title>
+    <Paragraph>
+      Welcome to the QCRM lead management system. Use the sidebar to navigate
+      through different sections. In <strong>Add New Lead</strong> you can submit
+      a new prospect. The <strong>All Leads</strong> section lists every lead
+      with actions to update their status. The <strong>Dashboard</strong> gives
+      you an overview of your pipeline. Update lead status to keep track of your
+      progress and ensure no opportunity is lost.
+    </Paragraph>
+    <Paragraph>
+      Select a lead to change its status between <em>active</em>, <em>on hold</em>
+      , or <em>closed</em>. Use the dashboard charts to monitor your overall
+      performance.
+    </Paragraph>
+  </Typography>
+);
+
+export default About;

--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -1,0 +1,64 @@
+import { Card, Row, Col, Statistic } from 'antd';
+import { Pie } from '@ant-design/plots';
+import { useGetLeads } from '../_actions/leads';
+
+const Dashboard = () => {
+  const { data = [], isLoading } = useGetLeads();
+
+  const total = data.length;
+  const active = data.filter((l) => l.status === 'active').length;
+  const closed = data.filter((l) => l.status === 'closed').length;
+  const onHold = data.filter((l) => l.status === 'on_hold').length;
+
+  const pieData = [
+    { type: 'Active', value: active },
+    { type: 'Closed', value: closed },
+    { type: 'On Hold', value: onHold },
+  ];
+
+  const config = {
+    data: pieData,
+    angleField: 'value',
+    colorField: 'type',
+    radius: 0.8,
+    label: {
+      type: 'inner',
+      offset: '-30%',
+      content: ({ percent }) => `${(percent * 100).toFixed(0)}%`,
+      style: { fontSize: 14, textAlign: 'center' },
+    },
+    interactions: [{ type: 'element-active' }],
+  };
+
+  return (
+    <div>
+      <Row gutter={16} style={{ marginBottom: 24 }}>
+        <Col span={6}>
+          <Card>
+            <Statistic title="Total Leads" value={total} loading={isLoading} />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card>
+            <Statistic title="Open" value={active} loading={isLoading} />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card>
+            <Statistic title="Closed" value={closed} loading={isLoading} />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card>
+            <Statistic title="On Hold" value={onHold} loading={isLoading} />
+          </Card>
+        </Col>
+      </Row>
+      <Card>
+        <Pie {...config} />
+      </Card>
+    </div>
+  );
+};
+
+export default Dashboard;


### PR DESCRIPTION
## Summary
- add `@ant-design/plots` dependency for dashboard chart
- implement sidebar menu with Dashboard, All Leads, Add New Lead and About sections
- create new Dashboard component showing lead statistics with a pie chart
- add About page with CRM usage instructions

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685544d84e44832d80650e3477430c08