### PR TITLE
Fix missing @ant-design/plots version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "three": "^0.155.0",
     "antd": "^5.13.6",
     "@tanstack/react-query": "^5.24.3",
-    "@ant-design/plots": "^1.5.17"
+    "@ant-design/plots": "^1.5.16"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
## Summary
- fix `npm install` error by using a known `@ant-design/plots` version

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855461904b8832d9bd52a8f939bea43