### PR TITLE
Remove ant-design plots

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "web-vitals": "^2.1.4",
     "three": "^0.155.0",
     "antd": "^5.13.6",
-    "@tanstack/react-query": "^5.24.3",
-    "@ant-design/plots": "^1.5.16"
+    "@tanstack/react-query": "^5.24.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -1,5 +1,4 @@
 import { Card, Row, Col, Statistic } from 'antd';
-import { Pie } from '@ant-design/plots';
 import { useGetLeads } from '../_actions/leads';
 
 const Dashboard = () => {
@@ -10,53 +9,50 @@ const Dashboard = () => {
   const closed = data.filter((l) => l.status === 'closed').length;
   const onHold = data.filter((l) => l.status === 'on_hold').length;
 
-  const pieData = [
-    { type: 'Active', value: active },
-    { type: 'Closed', value: closed },
-    { type: 'On Hold', value: onHold },
-  ];
-
-  const config = {
-    data: pieData,
-    angleField: 'value',
-    colorField: 'type',
-    radius: 0.8,
-    label: {
-      type: 'inner',
-      offset: '-30%',
-      content: ({ percent }) => `${(percent * 100).toFixed(0)}%`,
-      style: { fontSize: 14, textAlign: 'center' },
-    },
-    interactions: [{ type: 'element-active' }],
-  };
-
   return (
     <div>
       <Row gutter={16} style={{ marginBottom: 24 }}>
         <Col span={6}>
           <Card>
-            <Statistic title="Total Leads" value={total} loading={isLoading} />
+            <Statistic
+              title="Total Leads"
+              value={total}
+              loading={isLoading}
+              valueStyle={{ fontSize: '2.5rem' }}
+            />
           </Card>
         </Col>
         <Col span={6}>
           <Card>
-            <Statistic title="Open" value={active} loading={isLoading} />
+            <Statistic
+              title="Open"
+              value={active}
+              loading={isLoading}
+              valueStyle={{ fontSize: '2.5rem' }}
+            />
           </Card>
         </Col>
         <Col span={6}>
           <Card>
-            <Statistic title="Closed" value={closed} loading={isLoading} />
+            <Statistic
+              title="Closed"
+              value={closed}
+              loading={isLoading}
+              valueStyle={{ fontSize: '2.5rem' }}
+            />
           </Card>
         </Col>
         <Col span={6}>
           <Card>
-            <Statistic title="On Hold" value={onHold} loading={isLoading} />
+            <Statistic
+              title="On Hold"
+              value={onHold}
+              loading={isLoading}
+              valueStyle={{ fontSize: '2.5rem' }}
+            />
           </Card>
         </Col>
       </Row>
-      <Card>
-        <Pie {...config} />
-      </Card>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- drop `@ant-design/plots` dependency
- simplify dashboard to display cards only

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685547ac3438832dafed8fba24d987c2