### PR TITLE
Add logo and action buttons

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,6 +35,13 @@ function App() {
   return (
     <Layout style={{ minHeight: '100vh' }}>
       <Sider collapsible>
+        <div style={{ textAlign: 'center', padding: '16px 0' }}>
+          <img
+            src="https://api.qureal.com/assets/b90b0f1f-ac58-4462-beaf-8443326473a9"
+            alt="logo"
+            style={{ maxWidth: '80%', height: 40, objectFit: 'contain' }}
+          />
+        </div>
         <Menu
           theme="dark"
           mode="inline"

--- a/src/leads/AddLeadForm.js
+++ b/src/leads/AddLeadForm.js
@@ -22,9 +22,9 @@ const AddLeadForm = () => {
       form={form}
       layout="vertical"
       onFinish={onFinish}
-      style={{ maxWidth: 800, margin: '0 auto' }}
+      style={{ maxWidth: 800, margin: '0 auto', padding: 24 }}
     >
-      <Row gutter={16}>
+      <Row gutter={24}>
         <Col span={12}>
           <Form.Item
             label="Full Name"
@@ -44,7 +44,7 @@ const AddLeadForm = () => {
           </Form.Item>
         </Col>
       </Row>
-      <Row gutter={16}>
+      <Row gutter={24}>
         <Col span={12}>
           <Form.Item
             label="Contact Number"
@@ -60,7 +60,7 @@ const AddLeadForm = () => {
           </Form.Item>
         </Col>
       </Row>
-      <Row gutter={16}>
+      <Row gutter={24}>
         <Col span={12}>
           <Form.Item
             label="Email To"
@@ -90,6 +90,13 @@ const AddLeadForm = () => {
         <TextArea rows={4} />
       </Form.Item>
       <Form.Item style={{ textAlign: 'right' }}>
+        <Button
+          style={{ marginRight: 8 }}
+          onClick={() => form.resetFields()}
+          disabled={createLead.isPending}
+        >
+          Clear
+        </Button>
         <Button type="primary" htmlType="submit" loading={createLead.isPending}>
           Add Lead
         </Button>

--- a/src/leads/LeadsTable.js
+++ b/src/leads/LeadsTable.js
@@ -1,4 +1,5 @@
 import { Table, Tag, Button, message } from 'antd';
+import { MessageOutlined, MailOutlined, PhoneOutlined } from '@ant-design/icons';
 import { useGetLeads, useUpdateLead } from '../_actions/leads';
 
 const statusColors = {
@@ -63,9 +64,28 @@ const LeadsTable = () => {
     {
       title: 'Actions',
       key: 'actions',
-      render: (_, record) => {
-        if (record.status === 'active') {
-          return (
+      render: (_, record) => (
+        <>
+          <Button
+            size="small"
+            icon={<MessageOutlined />}
+            href={`https://wa.me/${record.contact_no}`}
+            target="_blank"
+            style={{ marginRight: 8 }}
+          />
+          <Button
+            size="small"
+            icon={<MailOutlined />}
+            href={`mailto:${record.email}`}
+            style={{ marginRight: 8 }}
+          />
+          <Button
+            size="small"
+            icon={<PhoneOutlined />}
+            href={`tel:${record.contact_no}`}
+            style={{ marginRight: 8 }}
+          />
+          {record.status === 'active' && (
             <>
               <Button
                 size="small"
@@ -82,20 +102,17 @@ const LeadsTable = () => {
                 Close
               </Button>
             </>
-          );
-        }
-        if (record.status === 'closed' || record.status === 'on_hold') {
-          return (
+          )}
+          {(record.status === 'closed' || record.status === 'on_hold') && (
             <Button
               size="small"
               onClick={() => handleStatusChange(record.id, 'active')}
             >
               Open
             </Button>
-          );
-        }
-        return null;
-      },
+          )}
+        </>
+      ),
     },
   ];
 


### PR DESCRIPTION
## Summary
- show project logo in the sidebar
- improve alignment in Add Lead form and add a clear button
- add quick contact buttons in the Leads table

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855497590c4832db34d2c991b035c5d