### PR TITLE
Add headings to screens

### DIFF
--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -1,5 +1,7 @@
-import { Card, Row, Col, Statistic } from 'antd';
+import { Card, Row, Col, Statistic, Typography } from 'antd';
 import { useGetLeads } from '../_actions/leads';
+
+const { Title } = Typography;
 
 const Dashboard = () => {
   const { data = [], isLoading } = useGetLeads();
@@ -11,6 +13,9 @@ const Dashboard = () => {
 
   return (
     <div>
+      <Title level={2} style={{ textAlign: 'center', marginBottom: 24 }}>
+        Dashboard
+      </Title>
       <Row gutter={16} style={{ marginBottom: 24 }}>
         <Col xs={12} md={6}>
           <Card>

--- a/src/leads/AddLeadForm.js
+++ b/src/leads/AddLeadForm.js
@@ -1,7 +1,8 @@
-import { Form, Input, Button, Select, message, Row, Col } from 'antd';
+import { Form, Input, Button, Select, message, Row, Col, Typography } from 'antd';
 import { useCreateLead } from '../_actions/leads';
 
 const { TextArea } = Input;
+const { Title } = Typography;
 
 const AddLeadForm = () => {
   const [form] = Form.useForm();
@@ -18,12 +19,16 @@ const AddLeadForm = () => {
   };
 
   return (
-    <Form
-      form={form}
-      layout="vertical"
-      onFinish={onFinish}
-      style={{ maxWidth: 800, margin: '0 auto', padding: 24 }}
-    >
+    <>
+      <Title level={2} style={{ textAlign: 'center', marginBottom: 24 }}>
+        Add New Lead
+      </Title>
+      <Form
+        form={form}
+        layout="vertical"
+        onFinish={onFinish}
+        style={{ maxWidth: 800, margin: '0 auto', padding: 24 }}
+      >
       <Row gutter={24}>
         <Col xs={24} md={12}>
           <Form.Item
@@ -102,6 +107,7 @@ const AddLeadForm = () => {
         </Button>
       </Form.Item>
     </Form>
+    </>
   );
 };
 

--- a/src/leads/LeadsTable.js
+++ b/src/leads/LeadsTable.js
@@ -1,6 +1,8 @@
-import { Table, Tag, Button, message } from 'antd';
+import { Table, Tag, Button, message, Typography } from 'antd';
 import { MessageOutlined, MailOutlined, PhoneOutlined } from '@ant-design/icons';
 import { useGetLeads, useUpdateLead } from '../_actions/leads';
+
+const { Title } = Typography;
 
 const statusColors = {
   active: 'green',
@@ -138,15 +140,20 @@ const LeadsTable = () => {
   ];
 
   return (
-    <Table
-      rowKey="id"
-      loading={isLoading}
-      columns={columns}
-      dataSource={data}
-      pagination={false}
-      style={{ marginTop: 20 }}
-      scroll={{ x: 800 }}
-    />
+    <>
+      <Title level={2} style={{ textAlign: 'center', marginBottom: 24 }}>
+        All Leads
+      </Title>
+      <Table
+        rowKey="id"
+        loading={isLoading}
+        columns={columns}
+        dataSource={data}
+        pagination={false}
+        style={{ marginTop: 20 }}
+        scroll={{ x: 800 }}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- add `Title` headings using Ant Design Typography on Dashboard, Add Lead, and All Leads screens

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554cb2e898832d880ab569b221c455